### PR TITLE
Made nameReturnValues in ModuleOutput public

### DIFF
--- a/src/module/uniol/apt/module/impl/ModuleOutputImpl.java
+++ b/src/module/uniol/apt/module/impl/ModuleOutputImpl.java
@@ -32,8 +32,8 @@ import uniol.apt.module.exception.ModuleException;
  *
  */
 public class ModuleOutputImpl implements ModuleOutput {
-	private final Map<String, Object> nameReturnValues = new HashMap<>();
-	private final ModuleOutputSpecImpl spec;
+	public final Map<String, Object> nameReturnValues = new HashMap<>();
+	public final ModuleOutputSpecImpl spec;
 
 	public ModuleOutputImpl(ModuleOutputSpecImpl spec) {
 		this.spec = spec;

--- a/src/module/uniol/apt/module/impl/ModuleOutputSpecImpl.java
+++ b/src/module/uniol/apt/module/impl/ModuleOutputSpecImpl.java
@@ -34,7 +34,7 @@ import uniol.apt.module.ModuleOutputSpec;
  *
  */
 public class ModuleOutputSpecImpl implements ModuleOutputSpec {
-	private final Map<String, ReturnValue> nameReturnValues = new LinkedHashMap<>();
+	public final Map<String, ReturnValue> nameReturnValues = new LinkedHashMap<>();
 
 	@Override
 	public void addReturnValue(String name, Class<?> klass,


### PR DESCRIPTION
In order to iterate threw the output of modules from an external library the HashMap needs to be public (otherwise you can only ask for a specific value).
